### PR TITLE
Add touch controls for iPad gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
         canvas {
             display: block;
             cursor: crosshair;
+            touch-action: none;
         }
         
         #ui {
@@ -45,7 +46,8 @@
     </div>
     
     <div id="instructions">
-        A/D: Move & Turn | Space: Jetpack Up | W: Jump | S/Down: Mine Below | Right Click: Place Block | T: Toggle Wall Mining | Keys 1-9: Select Block
+        A/D: Move & Turn | Space: Jetpack Up | W: Jump | S/Down: Mine Below | Right Click: Place Block | T: Toggle Wall Mining | Keys 1-9: Select Block<br>
+        Touch: Tap & hold to move Steve toward touch point | Upper half: Jetpack | Lower half: Walk/Fall
     </div>
     
     <script src="js/math.js"></script>

--- a/js/game.js
+++ b/js/game.js
@@ -5,6 +5,7 @@ class Game {
         this.world = new World();
         this.logoWorld = null; // Will be initialized when needed
         this.player = new Player();
+        this.player.setCanvasAndRenderer(this.canvas, this.renderer);
         this.lastTime = 0;
         this.isRunning = false;
         this.selectedBlockType = 1;


### PR DESCRIPTION
Implement tap-and-hold touch controls where Steve moves toward touch point:
- Touch upper half of screen: activates jetpack
- Touch lower half: horizontal movement
- Integrates with existing keyboard controls and mining system
- Prevents touch scrolling with touch-action: none

Fixes #5 